### PR TITLE
Custom CNAME enabled on VUE plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ Your Cloudimage customer token.
 Cloudimage account to get one. The subscription takes less than a
 minute and is totally free.
 
+### customDomain
+
+###### Type: **String** | Default: **"cloudimage.io"** | _optional_
+
+If you use a custom CNAME for your cloudimage integration, you can set it here.
+Note: this will disregard your token above as this should be built into the CNAME entry.
+
 ### baseURL
 
 ###### Type: **String** | Default: **"/"** | _optional_

--- a/examples/src/App.vue
+++ b/examples/src/App.vue
@@ -835,7 +835,13 @@ import Img, { CloudimageProvider } from 'vue-cloudimage-responsive';
 
 const cloudimageConfig = {
   token: 'demo',
-  baseURL: 'https://jolipage.airstore.io/'
+  baseURL: 'https://jolipage.airstore.io/',
+};
+
+const cloudimageConfigWithCustomCNAMEDomain = {
+  token: 'demo',
+  baseURL: 'https://jolipage.airstore.io/',
+  customDomain: 'images.airstore.io'
 };
 
 <template>

--- a/src/CloudImageProvider.vue
+++ b/src/CloudImageProvider.vue
@@ -14,7 +14,8 @@ export default {
     return {
       config: {
         token: this.cloudImageConfig.token || '',
-        domain: 'cloudimg.io',
+        domain: this.cloudImageConfig.customDomain || 'cloudimg.io',
+        customDomain: (this.cloudImageConfig.customDomain) || false,
         lazyLoading: this.cloudImageConfig.lazyLoading || true,
         lazyLoadOffset: this.cloudImageConfig.lazyLoadOffset || 100,
         placeholderBackground:


### PR DESCRIPTION
Allows custom CNAMES on the vue compoent.

Depends:  https://github.com/scaleflex/cloudimage-responsive-utils/pull/2